### PR TITLE
Call api and return the response

### DIFF
--- a/src/api_bot/agent.py
+++ b/src/api_bot/agent.py
@@ -92,6 +92,8 @@ class Agent():
                 if 'curl_command' in resp:
                     result = subprocess.run(resp['curl_command'], shell=True, capture_output=True, text=True)
                     if result.returncode == 0:
+                        result = result.stdout
+                    else:
                         result = "Below is expeted response:\n" + str(resp['expected_response'])
                 
                 responses += f"""Step {step}:\nEndpoint: {resp['endpoint']}\nDescription: {resp['description']}\nCurl Command:\n{resp['curl_command']}\nResponse:\n{result}\n"""

--- a/src/api_bot/agent.py
+++ b/src/api_bot/agent.py
@@ -57,9 +57,13 @@ class Agent():
     
     def ask(self, question):
         ret: dict = self.engine1.ask(question)
+        
+        if 'status' in ret and ret['status'] == 'not_found':
+                return "Sorry, I don't have the information for your query."
+        
         if 'operation_ids' not in ret:
             return "Sorry, can you please provide more information?"
-        
+            
         stage2_prompt = self.get_stage2_prompt() 
         self.start_next_stage(stage2_prompt)
         

--- a/src/api_bot/agent.py
+++ b/src/api_bot/agent.py
@@ -1,5 +1,5 @@
-import json
 import os
+import subprocess
 
 from api_bot.openapi_parser import OpenApiParser, OpenApiParts
 from api_bot.chat import Chat
@@ -59,7 +59,7 @@ class Agent():
         ret: dict = self.engine1.ask(question)
         
         if 'status' in ret and ret['status'] == 'not_found':
-                return "Sorry, I don't have the information for your query."
+            return "Sorry, I don't have the information for your query."
         
         if 'operation_ids' not in ret:
             return "Sorry, can you please provide more information?"
@@ -68,7 +68,8 @@ class Agent():
         self.start_next_stage(stage2_prompt)
         
         responses = ""
-        for order, op_id in enumerate(ret['operation_ids']):
+        step = 1
+        for op_id in ret['operation_ids']:
             
             if op_id in self.openapi_info:
                 info = self.openapi_info[op_id]
@@ -79,9 +80,24 @@ class Agent():
                 request = f'request: {self.openapi_request[op_id]}\n'
                 response = f'response: {self.openapi_response[op_id]}\n'
             
-                inp = "Below is the useful information for the api:\n" + path + method + description + security + request + response
+                inp = f"User Query: {question}\n\nBelow is the useful information for the api:\npath: {path}\nmethod: {method}\ndescription: {description}\nsecurity: {security}\nrequest body: {request}\nresponse body: {response}"
+                
                 resp = self.engine2.ask(inp)
-                responses += f"Step {order+1}:, {resp}\n\n"
+                
+                if 'status' in resp and resp['status'] == 'lack_of_info':
+                    if 'description' in resp:
+                        return resp['description']
+                    return "Sorry, You need to provide me more information."
+                
+                if 'curl_command' in resp:
+                    result = subprocess.run(resp['curl_command'], shell=True, capture_output=True, text=True)
+                    if result.returncode == 0:
+                        result = "Below is expeted response:\n" + str(resp['expected_response'])
+                
+                responses += f"""Step {step}:\nEndpoint: {resp['endpoint']}\nDescription: {resp['description']}\nCurl Command:\n{resp['curl_command']}\nResponse:\n{result}\n"""
+                step += 1
+
         if responses == "":
            return "Sorry, I don't have the information for your query."
+
         return responses

--- a/src/api_bot/chat.py
+++ b/src/api_bot/chat.py
@@ -1,8 +1,9 @@
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain_aws import ChatBedrock
 from langchain.prompts.prompt import PromptTemplate
-from langchain_core.output_parsers import StrOutputParser
+from langchain_core.output_parsers import JsonOutputParser
 
+from api_bot.stage2_parser import Instructions
 class Chat:
     _messages = []
     def __init__(
@@ -24,7 +25,7 @@ class Chat:
             AI Assistant:
         """
         
-        parser = StrOutputParser()
+        parser = JsonOutputParser(pydantic_object=Instructions)
         
         prompt = PromptTemplate(
             template=template,

--- a/src/api_bot/main.py
+++ b/src/api_bot/main.py
@@ -41,8 +41,5 @@ def start_api_selector(
     api_selector.start()
     ask_question = api_selector.ask_question
 
-    while True:
-        inp = input(">>> ")
-        if inp == "exit": 
-            break
-        print(ask_question(inp))
+    inp = input(">>> ")
+    print(ask_question(inp))

--- a/src/api_bot/operation_ids_chat.py
+++ b/src/api_bot/operation_ids_chat.py
@@ -3,7 +3,8 @@ from langchain_aws import ChatBedrock
 from langchain_core.output_parsers import JsonOutputParser
 from langchain.prompts.prompt import PromptTemplate
 
-from api_bot.output_parser import OperationIds
+from api_bot.stage1_parser import OperationIds
+
 
 class OperationIdChat:
     _messages = []

--- a/src/api_bot/stage1_parser.py
+++ b/src/api_bot/stage1_parser.py
@@ -1,4 +1,5 @@
 from langchain_core.pydantic_v1 import BaseModel, Field
 
 class OperationIds(BaseModel):
+    status: str = Field(description="status of the query")
     operation_ids: list = Field(description="operation ids for the query")

--- a/src/api_bot/stage2_parser.py
+++ b/src/api_bot/stage2_parser.py
@@ -1,0 +1,9 @@
+from langchain_core.pydantic_v1 import BaseModel, Field
+
+class Instructions(BaseModel):
+    status: str = Field(description="status of the query")
+    endpoint: str = Field(description="endpoint of the api")
+    description: str = Field(description="description of the api")
+    curl_commmand: str = Field(description="command to run the api")
+    expected_response: str = Field(description="response of the api")
+    

--- a/src/prompt/stage1_prompt.txt
+++ b/src/prompt/stage1_prompt.txt
@@ -2,23 +2,28 @@ Your task is to directly translate user queries into corresponding operation_ids
 
 Instructions:
 
+- Format your response strictly as a JSON object containing the 'operation_ids' and 'status' keys.
 - Refer to the API call definitions provided in the CSV format to identify the appropriate operation_ids.
-- If multiple API calls have similar functions, select only one that best matches the user query.
-- Format your response strictly as a JSON object containing only the 'operation_ids' key with an array of operation ids as its value.
+- If multiple API calls have similar functions, select only the most general one that best matches the user query.
 - Your response should consist only of this JSON object. Avoid adding any line breaks, additional text, or explanations.
 
 Required Field:
+- status
 - operation_ids
 
 JSON Response Format:
-- Ensure that the response contains only the JSON object with the 'operation_ids'.
-- If no corresponding operation_id can be identified, the 'operation_ids' array should contain 'null'.
+- Ensure that the response contains only the JSON object with the 'operation_ids', 'status'.
+- If no corresponding operation_id can be identified, the 'operation_ids' array should contain 'null', the 'status' should be 'not_found'.
+- If everything is correct, the 'status' should be 'ok'.
 
 Example Output 1:
-{{{{"operation_ids":["ListShipments"]}}}}
+{{{{"operation_ids":["ListShipments"], "status": "ok"}}}}
 
 Example Output 2:
-{{{{"operation_ids":["ListShipments", "GetInvoices"]}}}}
+{{{{"operation_ids":["ListShipments", "GetInvoices"], "status": "ok"}}}}
+
+Example Output 3:
+{{{{"operation_ids":["null"], "status": "not_found"}}}}
 
 Below is the list of API call definitions in CSV format:
 {method_definitions}

--- a/src/prompt/stage2_prompt.txt
+++ b/src/prompt/stage2_prompt.txt
@@ -1,31 +1,34 @@
-Now, You are tasked with analyzing user requests and identifying the correct API calls along with their necessary parameters. Your responses should be detailed and provide step-by-step guidance for using each identified API.
-
-Each time, only transmit the data of one API. The numbers indicate the order.
+You are tasked with analyzing user requests and identifying the correct API calls along with their necessary parameters. Your responses should be detailed and provide step-by-step guidance for using each identified API.
 
 Base URL is {base_url}, and api key is {gf_api_key}
 
-Output format:
-```
-API Endpoint: [API endpoint]
-Description: [API DESCRIPTION]
-Usage:
-[HTTP REQUEST]
-After a successful request, you’ll receive a response similar to this one: 
-[RESPONSE]
-```
-
-Details to Include:
-[ORDER] The numbers indicate the order.
-[API endpoint] should be the complete path of the API.
-[HTTP REQUEST] must be formatted for use with curl, including all necessary headers and data fields (if applicable).
-[RESPONSE] should be a valid JSON object, demonstrating what the user can expect to receive after a successful API call.
+If the user does not provide the fields that are required in the request body, return the status "lack_of_info" and specify which fields are missing in the description field.
 
 Here is an example:
 User Query: 'Create Ocean Shipments for me.'
 You need to response: 
-```
-1. API Endpoint: /create-ocean-shipments
-2. Description: Initiates a new ocean shipment.
-3. Usage: curl -X POST {base_url}/create-ocean-shipments -H 'Content-Type: application/json' -H 'X-GATEWAY-TOKEN: {gf_api_key}' -d {{{{"shipmentDetails": ...}}}}
-4. After a successful request, you’ll receive a response similar to this one: {{{{"status": "success", "shipmentId": "12345"}}}}
-```
+{{{{
+    "status": "lack_of_info",
+    "description": "You need to provide more information, such as 'office_ref', 'hbl_list'..."
+}}}}
+
+If you can find all the fields in the user query, return below infofrmation to user.
+
+Details to Include:
+"endpoint" should be the complete path of the API. 
+"description" should be the description of the API
+"curl_command" must be formatted for use with curl, including all necessary headers and data fields (if applicable). You can refer to the request body.
+"expected_response" should be a valid JSON object, demonstrating what the user can expect to receive after a successful API call. You can refer to the response body.
+
+Here is an example:
+
+User Query: 'List all shipments'
+
+Output format:
+{{{{
+    "status": "ok",
+    "endpoint": "/api/v1/shipments",
+    "description": "List ocean shipment.",
+    "curl_command": "curl -X GET {base_url}//api/v1/shipments -H 'Content-Type: application/json' -H 'X-GATEWAY-TOKEN: {gf_api_key}'",
+    "expected_response": {{{{"status": "success", "shipmentId": "12345"}}}}
+}}}}


### PR DESCRIPTION
### Handle queries not documented in the API:
- Add a `status` field to the stage1 output parser.
- The status can be `ok` or `not_found`. 
    - If `ok`, continue processing. 
    - If `not_found`, inform the user that the query cannot be handled.

### API calling
- Change the output parser from **string** to **json** to extract the `curl_command` field and obtain the response.
    - If the `curl_command` executes successfully, use its response.
    - If the `curl_command` fails, use the expected response from the API document.
- Update to a new version of the stage2 prompt.